### PR TITLE
Fix discord media in matrix

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -94,6 +94,7 @@ jobs:
           MATRIX_SLIDING_SYNC_POSTGRES_PASSWORD: ${{ secrets.MATRIX_SLIDING_SYNC_POSTGRES_PASSWORD }}
           MATRIX_SLIDING_SYNC_POSTGRES_CONNECTION_STRING: ${{ secrets.MATRIX_SLIDING_SYNC_POSTGRES_CONNECTION_STRING }}
           MATRIX_SLIDING_SYNC_SECRET: ${{ secrets.MATRIX_SLIDING_SYNC_SECRET }}
+          MATRIX_DISCORD_RESOLVER_ACCOUNT_TOKEN: ${{ secrets.matrix_discord_resolver_account_token }}
         run: |
           sed -i "s|(matrix_postgres_password)|$POSTGRES_PASSWORD|g" $GITHUB_WORKSPACE/matrix/docker-compose.yml
           sed -i "s|(matrix_telegram_postgres_password)|$MATRIX_TELEGRAM_POSTGRES_PASSWORD|g" $GITHUB_WORKSPACE/matrix/docker-compose.yml
@@ -101,6 +102,7 @@ jobs:
           sed -i "s|(MATRIX_SLIDING_SYNC_POSTGRES_PASSWORD)|$MATRIX_SLIDING_SYNC_POSTGRES_PASSWORD|g" $GITHUB_WORKSPACE/matrix/docker-compose.yml
           sed -i "s|(MATRIX_SLIDING_SYNC_POSTGRES_CONNECTION_STRING)|$MATRIX_SLIDING_SYNC_POSTGRES_CONNECTION_STRING|g" $GITHUB_WORKSPACE/matrix/docker-compose.yml
           sed -i "s|(MATRIX_SLIDING_SYNC_SECRET)|$MATRIX_SLIDING_SYNC_SECRET|g" $GITHUB_WORKSPACE/matrix/docker-compose.yml
+          sed -i "s|(matrix_discord_resolver_account_token)|$MATRIX_DISCORD_RESOLVER_ACCOUNT_TOKEN|g" $GITHUB_WORKSPACE/matrix/docker-compose.yml
 
       - name: create file for secrets
         env:

--- a/caddy/configs/matrix.caddyfile
+++ b/caddy/configs/matrix.caddyfile
@@ -1,14 +1,14 @@
 matrix.aosus.org {
-	# proxy direct images from discord CDN instead of uploading (https://docs.mau.fi/bridges/go/discord/direct-media.html)
+	# redirect image requests to discord CDN instead of uploading with a workaround for signed URL requirement (https://github.com/aosus/infrastructure-meta/issues/5)
 	handle /_matrix/media/*/download/aosus.org/discord_* {
 		header Access-Control-Allow-Origin *
 		# Remove path prefix
-		uri path_regexp ^/_matrix/media/.+/download/aosus\.org/discord_ /
-		# The mxc patterns use | instead of /, so replace it first turning it into attachments/1234/5678/filename.png
+		uri path_regexp ^/_matrix/media/.+/download/aosus\.org/discord_ "/https://cdn.discordapp.com/"
+		# The mxc patterns use | instead of /, so replace it first turning it into attachments/1234/5678/filename.png, and add "https://cdn.discordapp.com" so discord-resolver could fetch a signed url.
 		uri replace "%7C" /
 		reverse_proxy {
 			# reverse_proxy automatically includes the uri, so no {uri} at the end
-			to https://cdn.discordapp.com
+			to discord-resolver:3000
 			# Caddy doesn't set the Host header automatically when reverse proxying
 			# (because usually reverse proxies are local and don't care about Host headers)
 			header_up Host cdn.discordapp.com
@@ -18,10 +18,10 @@ matrix.aosus.org {
 	# Alternatively, you can point this at cdn.discordapp.com too. Clients shouldn't mind even if they get a bigger image than they asked for.
 	handle /_matrix/media/*/thumbnail/aosus.org/discord_* {
 		header Access-Control-Allow-Origin *
-		uri path_regexp ^/_matrix/media/.+/thumbnail/aosus\.org/discord_ /
+		uri path_regexp ^/_matrix/media/.+/thumbnail/aosus\.org/discord_ "/https://media.discordapp.net/"
 		uri replace "%7C" /
 		reverse_proxy {
-			to https://media.discordapp.net
+			to discord-resolver:3000
 			header_up Host media.discordapp.net
 		}
 	}

--- a/matrix/docker-compose.yml
+++ b/matrix/docker-compose.yml
@@ -108,6 +108,16 @@ services:
     volumes:
       - discord-postgres:/var/lib/postgresql/data:rw
 
+# Discord now requires signed URLs for their CDN, this resolver fetches signed urls using a user token, and redirects the user to it.
+  discord-resolver:
+    image: ghcr.io/aosus/discord_cdn:master
+    # ports:
+    #   - 3000:3000
+    environment:
+      - TOKEN=(matrix_discord_resolver_account_token)
+      - CACHE=86400 # cache discord links for a day
+    networks:
+      - web
 
   eturnal:
     image: ghcr.io/processone/eturnal:edge@sha256:a47da8b6269b6946f154e8d00f44887ebfef9908361afc8348760ab1853b0e7c


### PR DESCRIPTION
This PR introduces a fix for media coming from discord without needing to store them on the server.
It uses our fork of the discord_cdn project (https://github.com/aosus/Discord_CDN), which has some patches to make it work well in docker.

It will redirect any normal CDN links to signed ones fetched using a user token.

This workaround doesn't proxy the redirect (couldn't figure it out), which means this won't work with homeservers without support for [MSC3860](https://github.com/matrix-org/matrix-spec-proposals/pull/3860), but since synapse supports it, that pretty much covers 95% of matrix server out there.

fix https://github.com/aosus/infrastructure-meta/issues/5